### PR TITLE
fix: secretId configuration key

### DIFF
--- a/src/Itmo.Dev.Platform.YandexCloud/Configuration/Links/YandexCloudConfigurationLink.cs
+++ b/src/Itmo.Dev.Platform.YandexCloud/Configuration/Links/YandexCloudConfigurationLink.cs
@@ -20,7 +20,7 @@ internal class YandexCloudConfigurationLink : IAsyncLink<ConfigurationCommand>
             return await next(request, context);
         }
 
-        string secretId = request.ApplicationBuilder.Configuration.GetValue<string>("Platform:YandexCloud:SecretId")
+        string secretId = request.ApplicationBuilder.Configuration.GetValue<string>("Platform:YandexCloud:LockBox:SecretId")
                           ?? throw new YandexCloudException("SecretId must be defined for Yandex Cloud deployment");
 
         var yandexCloudService = new YandexCloudService(request.ApplicationBuilder.Configuration);


### PR DESCRIPTION
Unhandled exception.
Itmo.Dev.Platform.YandexCloud.Exceptions.YandexCloudException SecretId must be defined for Yandex Cloud deployment